### PR TITLE
Updating the Pgtoolsservice to latest minor release

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/pgtoolsservice/releases/download/{#version#}/pgsqltoolsservice-{#fileName#}",
-	"version": "v1.0.0",
+	"version": "v1.1.0",
 	"downloadFileNames": {
 		"Windows_64": "win-x64.zip",
 		"Windows_86": "win-x86.zip",


### PR DESCRIPTION
It looks like the latest version of PG Tool Service has addressed the JSONB issue: https://github.com/microsoft/azuredatastudio-postgresql/issues/94

So bumping the requirement to 1.1.0
https://github.com/microsoft/pgtoolsservice/pull/208