### PR TITLE
Change output channel to not take focus when installing service

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -122,10 +122,10 @@ function generateServerOptions(executablePath: string): ServerOptions {
 function generateHandleServerProviderEvent() {
 	let dots = 0;
 	return (e: string, ...args: any[]) => {
-		outputChannel.show();
-		statusView.show();
 		switch (e) {
 			case Events.INSTALL_START:
+				outputChannel.show(true);
+				statusView.show();
 				outputChannel.appendLine(`Installing ${Constants.serviceName} service to ${args[0]}`);
 				statusView.text = 'Installing Service';
 				break;

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,6 +147,9 @@ function generateHandleServerProviderEvent() {
 			case Events.DOWNLOAD_END:
 				outputChannel.appendLine('Done!');
 				break;
+			default:
+				console.error(`Unknown event from Server Provider ${e}`);
+				break;
 		}
 	};
 }


### PR DESCRIPTION
Change showing of message window to not take focus when shown
Only show the message window on install start so that if user closes it it'll stay closed (we can assume they're not interested in the messages if they close it after the initial one)

Fixes https://github.com/microsoft/azuredatastudio/issues/6110 https://github.com/microsoft/azuredatastudio/issues/6157 https://github.com/microsoft/azuredatastudio/issues/5149