### PR TITLE
Support Active Directory login for PostgreSQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
       "providerName": "PGSQL",
       "providerId": "PGSQL",
       "displayName": "PostgreSQL",
+      "azureResource": 2,
       "connectionOptions": [
         {
           "specialValueType": "connectionName",
@@ -162,6 +163,29 @@
           "defaultValue": null,
           "objectType": null,
           "categoryValues": null,
+          "isArray": false
+        },
+        {
+          "specialValueType": "authType",
+          "isIdentity": true,
+          "name": "authenticationType",
+          "displayName": "Authentication type",
+          "description": "How to authenticate with server",
+          "groupName": "Security",
+          "valueType": "category",
+          "defaultValue": null,
+          "objectType": null,
+          "categoryValues": [
+            {
+              "displayName": "Password",
+              "name": "SqlLogin"
+            },
+            {
+              "displayName": "Azure Account",
+              "name": "AzureMFA"
+            }
+          ],
+          "isRequired": true,
           "isArray": false
         },
         {

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
               "name": "SqlLogin"
             },
             {
-              "displayName": "Azure Account",
+              "displayName": "Azure Active Directory",
               "name": "AzureMFAAndUser"
             }
           ],

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
       "providerName": "PGSQL",
       "providerId": "PGSQL",
       "displayName": "PostgreSQL",
-      "azureResource": 2,
+      "azureResource": "OssRdbms",
       "connectionOptions": [
         {
           "specialValueType": "connectionName",

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
           "description": "How to authenticate with server",
           "groupName": "Security",
           "valueType": "category",
-          "defaultValue": null,
+          "defaultValue": "SqlLogin",
           "objectType": null,
           "categoryValues": [
             {
@@ -182,7 +182,7 @@
             },
             {
               "displayName": "Azure Account",
-              "name": "AzureMFA"
+              "name": "AzureMFAAndUser"
             }
           ],
           "isRequired": true,


### PR DESCRIPTION
AAD login for PostgreSQL on Azure is slightly different than for SQL on Azure. For one thing, it requires a different AAD resource identifier. For another, it requires both the AAD login and tenant to be specified, but also a database username. 

This change does the following:

- Specifies that the AAD resource is for OSS RDBMSs. 
- Adds authentication type to the PostgreSQL connection dialog.
- Defaults authentication type to username/password.
- Provides for authentication type "AzureMFAAndUser", which allows the user to specify an Azure AAD login and tenant along with the database username.