### PR TITLE
Have ADS treat connections as different through port and host 

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
           "displayName": "Host IP address",
           "description": "IP address of the server",
           "valueType": "string",
+          "isIdentity": true,
           "groupName": "Server",
           "defaultValue": null
         },
@@ -228,6 +229,7 @@
           "displayName": "Port",
           "description": "Port number for the server",
           "valueType": "number",
+          "isIdentity": true,
           "groupName": "Server",
           "defaultValue": null
         },


### PR DESCRIPTION
Add 'isIdentity= true' to the port and host option in package.json, this will make ADS be able to treat them as different connections.

Tied with ADS fix: https://github.com/microsoft/azuredatastudio/pull/17229

This PR fixes #113 