### PR TITLE
Add Syntax highlighting on TRUNC() function

### DIFF
--- a/syntaxes/pgsql-injection.json
+++ b/syntaxes/pgsql-injection.json
@@ -9,7 +9,7 @@
 		"pgsql-keywords": {
 			"patterns": [{
 				"name": "keyword.pgsql.sql",
-				"match": "\\b(?i)(conflict|do|exception)\\b"
+				"match": "\\b(?i)(conflict|do|exception|trunc)\\b"
 			}]
 		}
 	},


### PR DESCRIPTION
fix https://github.com/microsoft/azuredatastudio-postgresql/issues/261
before
<img width="463" alt="image" src="https://github.com/microsoft/azuredatastudio-postgresql/assets/69922333/061d6b12-f82d-4193-8956-0925d0956479">

after
<img width="575" alt="image" src="https://github.com/microsoft/azuredatastudio-postgresql/assets/69922333/7b95de47-425c-464f-af8e-c911262fecdb">
