### PR TITLE
Support Linux executable and Disable code sign for offline package

### DIFF
--- a/.pipeline/insiders-pipeline.yml
+++ b/.pipeline/insiders-pipeline.yml
@@ -1,10 +1,60 @@
 trigger: none
 pr: none
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'ubuntu-latest'
+
 steps:
-- template: templates/build.yml
-- template: templates/code-sign.yml
+- task: NodeTool@0
+  inputs:
+    versionSpec: '14.x'
+  displayName: 'Install Node.js'
+- task: CmdLine@2
+  displayName: 'Installing Dependencies'
+  inputs:
+    script: |
+      sudo npm install -g yarn
+      sudo npm install -g vsce
+- task: CmdLine@2
+  displayName: 'Building Vsix Packages'
+  inputs:
+    script: |
+      yarn install
+      yarn run compile
+      yarn run package
+      yarn run package-offline-windows
+      yarn run package-offline-osx
+      yarn run package-offline-osx-arm64
+- task: EsrpCodeSigning@3
+  displayName: 'Code Signing'
+  inputs:
+    ConnectedServiceName: 'Database System ESRP Connector'
+    FolderPath: '$(Build.SourcesDirectory)'
+    Pattern: '*.vsix'
+    useMinimatch: true
+    signConfigType: inlineSignParams
+    inlineOperation: |
+      [
+        {
+            "KeyCode" : "CP-233016",
+            "OperationCode" : "OpcSign",
+            "Parameters" : {
+                "FileDigest" : "/fd SHA256"
+            },
+            "ToolName" : "sign",
+            "ToolVersion" : "1.0"
+        },
+        {
+            "KeyCode" : "CP-233016",
+            "OperationCode" : "OpcVerify",
+            "Parameters" : {},
+            "ToolName" : "sign",
+            "ToolVersion" : "1.0"
+        }
+      ]
+    SessionTimeout: '60'
+    MaxConcurrency: '50'
+    MaxRetryAttempts: '5'
+    excludePattern: '**/out/ossdbtoolsservice/**'
 - task: CopyFiles@2
   inputs:
     sourceFolder: '$(Build.SourcesDirectory)'

--- a/.pipeline/insiders-pipeline.yml
+++ b/.pipeline/insiders-pipeline.yml
@@ -1,23 +1,7 @@
 trigger: none
 pr: none
-strategy:
-  matrix:
-    linux:
-      platform: 'ubuntu'
-      imageName: 'windows-latest'
-      archiveType: 'tar'
-    mac-x64:
-      platform: 'mac-x64'
-      imageName: 'windows-latest'
-      archiveType: 'tar'
-    mac-arm64:
-      platform: 'mac-arm64'
-      imageName: 'windows-latest'
-    windows:
-      platform: 'windows'
-      imageName: 'windows-latest'
 pool:
-  vmImage: $(imageName)
+  vmImage: 'windows-latest'
 steps:
 - template: templates/build.yml
 - template: templates/code-sign.yml

--- a/.pipeline/insiders-pipeline.yml
+++ b/.pipeline/insiders-pipeline.yml
@@ -1,60 +1,26 @@
 trigger: none
 pr: none
+strategy:
+  matrix:
+    linux:
+      platform: 'ubuntu'
+      imageName: 'ubuntu-latest'
+      archiveType: 'tar'
+    mac-x64:
+      platform: 'mac-x64'
+      imageName: 'macOS-latest'
+      archiveType: 'tar'
+    mac-arm64:
+      platform: 'mac-arm64'
+      imageName: 'macOS-latest'
+    windows:
+      platform: 'windows'
+      imageName: 'windows-latest'
 pool:
-  vmImage: 'ubuntu-latest'
-
+  vmImage: $(imageName)
 steps:
-- task: NodeTool@0
-  inputs:
-    versionSpec: '14.x'
-  displayName: 'Install Node.js'
-- task: CmdLine@2
-  displayName: 'Installing Dependencies'
-  inputs:
-    script: |
-      sudo npm install -g yarn
-      sudo npm install -g vsce
-- task: CmdLine@2
-  displayName: 'Building Vsix Packages'
-  inputs:
-    script: |
-      yarn install
-      yarn run compile
-      yarn run package
-      yarn run package-offline-windows
-      yarn run package-offline-osx
-      yarn run package-offline-osx-arm64
-- task: EsrpCodeSigning@3
-  displayName: 'Code Signing'
-  inputs:
-    ConnectedServiceName: 'Database System ESRP Connector'
-    FolderPath: '$(Build.SourcesDirectory)'
-    Pattern: '*.vsix'
-    useMinimatch: true
-    signConfigType: inlineSignParams
-    inlineOperation: |
-      [
-        {
-            "KeyCode" : "CP-233016",
-            "OperationCode" : "OpcSign",
-            "Parameters" : {
-                "FileDigest" : "/fd SHA256"
-            },
-            "ToolName" : "sign",
-            "ToolVersion" : "1.0"
-        },
-        {
-            "KeyCode" : "CP-233016",
-            "OperationCode" : "OpcVerify",
-            "Parameters" : {},
-            "ToolName" : "sign",
-            "ToolVersion" : "1.0"
-        }
-      ]
-    SessionTimeout: '60'
-    MaxConcurrency: '50'
-    MaxRetryAttempts: '5'
-    excludePattern: '**/out/ossdbtoolsservice/**'
+- template: templates/build.yml
+- template: templates/code-sign.yml
 - task: CopyFiles@2
   inputs:
     sourceFolder: '$(Build.SourcesDirectory)'

--- a/.pipeline/insiders-pipeline.yml
+++ b/.pipeline/insiders-pipeline.yml
@@ -8,11 +8,11 @@ strategy:
       archiveType: 'tar'
     mac-x64:
       platform: 'mac-x64'
-      imageName: 'macOS-latest'
+      imageName: 'ubuntu-latest'
       archiveType: 'tar'
     mac-arm64:
       platform: 'mac-arm64'
-      imageName: 'macOS-latest'
+      imageName: 'ubuntu-latest'
     windows:
       platform: 'windows'
       imageName: 'windows-latest'

--- a/.pipeline/insiders-pipeline.yml
+++ b/.pipeline/insiders-pipeline.yml
@@ -4,15 +4,15 @@ strategy:
   matrix:
     linux:
       platform: 'ubuntu'
-      imageName: 'ubuntu-latest'
+      imageName: 'windows-latest'
       archiveType: 'tar'
     mac-x64:
       platform: 'mac-x64'
-      imageName: 'ubuntu-latest'
+      imageName: 'windows-latest'
       archiveType: 'tar'
     mac-arm64:
       platform: 'mac-arm64'
-      imageName: 'ubuntu-latest'
+      imageName: 'windows-latest'
     windows:
       platform: 'windows'
       imageName: 'windows-latest'

--- a/.pipeline/release-pipeline.yml
+++ b/.pipeline/release-pipeline.yml
@@ -9,11 +9,11 @@ strategy:
       archiveType: 'tar'
     mac-x64:
       platform: 'mac-x64'
-      imageName: 'macOS-latest'
+      imageName: 'ubuntu-latest'
       archiveType: 'tar'
     mac-arm64:
       platform: 'mac-arm64'
-      imageName: 'macOS-latest'
+      imageName: 'ubuntu-latest'
     windows:
       platform: 'windows'
       imageName: 'windows-latest'

--- a/.pipeline/release-pipeline.yml
+++ b/.pipeline/release-pipeline.yml
@@ -9,11 +9,11 @@ strategy:
       archiveType: 'tar'
     mac-x64:
       platform: 'mac-x64'
-      imageName: 'ubuntu-latest'
+      imageName: 'macOS-latest'
       archiveType: 'tar'
     mac-arm64:
       platform: 'mac-arm64'
-      imageName: 'ubuntu-latest'
+      imageName: 'macOS-latest'
     windows:
       platform: 'windows'
       imageName: 'windows-latest'

--- a/.pipeline/templates/build.yml
+++ b/.pipeline/templates/build.yml
@@ -13,7 +13,9 @@ steps:
   displayName: 'Installing Dependencies and build packages'
   condition: eq(variables['platform'], 'windows')
 
-- task: CmdLine@2
+- task: NodeTool@0
+  inputs:
+    versionSpec: '14.x'
   displayName: 'Installing Dependencies and build packages'
   condition: eq(variables['platform'], 'mac-x64')
   inputs:
@@ -24,7 +26,9 @@ steps:
       yarn run compile
       yarn run package-offline-osx
 
-- task: CmdLine@2
+- task: NodeTool@0
+  inputs:
+    versionSpec: '14.x'
   displayName: 'Installing Dependencies and build packages'
   condition: eq(variables['platform'], 'mac-arm64')
   inputs:

--- a/.pipeline/templates/build.yml
+++ b/.pipeline/templates/build.yml
@@ -34,3 +34,14 @@ steps:
       yarn install
       yarn run compile
       yarn run package-offline-osx-arm64
+
+- task: CmdLine@2
+  displayName: 'Installing Dependencies and build packages'
+  condition: eq(variables['platform'], 'ubuntu')
+  inputs:
+    script: |
+      npm install -g yarn
+      npm install -g vsce
+      yarn install
+      yarn run compile
+      yarn run package-offline-linux

--- a/.pipeline/templates/build.yml
+++ b/.pipeline/templates/build.yml
@@ -10,31 +10,6 @@ steps:
     yarn run compile
     yarn run package
     yarn run package-offline-windows
+    yarn run package-offline-osx
+    yarn run package-offline-osx-arm64
   displayName: 'Installing Dependencies and build packages'
-  condition: eq(variables['platform'], 'windows')
-
-- task: NodeTool@0
-  inputs:
-    versionSpec: '14.x'
-  displayName: 'Installing Dependencies and build packages'
-  condition: eq(variables['platform'], 'mac-x64')
-  inputs:
-    script: |
-      npm install -g yarn
-      npm install -g vsce
-      yarn install
-      yarn run compile
-      yarn run package-offline-osx
-
-- task: NodeTool@0
-  inputs:
-    versionSpec: '14.x'
-  displayName: 'Installing Dependencies and build packages'
-  condition: eq(variables['platform'], 'mac-arm64')
-  inputs:
-    script: |
-      npm install -g yarn
-      npm install -g vsce
-      yarn install
-      yarn run compile
-      yarn run package-offline-osx-arm64

--- a/.pipeline/templates/build.yml
+++ b/.pipeline/templates/build.yml
@@ -10,6 +10,27 @@ steps:
     yarn run compile
     yarn run package
     yarn run package-offline-windows
-    yarn run package-offline-osx
-    yarn run package-offline-osx-arm64
   displayName: 'Installing Dependencies and build packages'
+  condition: eq(variables['platform'], 'windows')
+
+- task: CmdLine@2
+  displayName: 'Installing Dependencies and build packages'
+  condition: eq(variables['platform'], 'mac-x64')
+  inputs:
+    script: |
+      npm install -g yarn
+      npm install -g vsce
+      yarn install
+      yarn run compile
+      yarn run package-offline-osx
+
+- task: CmdLine@2
+  displayName: 'Installing Dependencies and build packages'
+  condition: eq(variables['platform'], 'mac-arm64')
+  inputs:
+    script: |
+      npm install -g yarn
+      npm install -g vsce
+      yarn install
+      yarn run compile
+      yarn run package-offline-osx-arm64

--- a/.pipeline/templates/code-sign.yml
+++ b/.pipeline/templates/code-sign.yml
@@ -29,3 +29,4 @@ steps:
     SessionTimeout: '60'
     MaxConcurrency: '50'
     MaxRetryAttempts: '5'
+    excludePattern: '**/out/ossdbtoolsservice/**'

--- a/.pipeline/templates/code-sign.yml
+++ b/.pipeline/templates/code-sign.yml
@@ -29,4 +29,4 @@ steps:
     SessionTimeout: '60'
     MaxConcurrency: '50'
     MaxRetryAttempts: '5'
-    excludePattern: '**/out/ossdbtoolsservice/**'
+  condition: eq(variables['platform'], 'windows')

--- a/.pipeline/templates/code-sign.yml
+++ b/.pipeline/templates/code-sign.yml
@@ -1,5 +1,5 @@
 steps:
-- task: EsrpCodeSigning@2
+- task: EsrpCodeSigning@3
   displayName: 'Code Signing'
   inputs:
     ConnectedServiceName: 'Database System ESRP Connector'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "package-offline": "gulp package:offline",
     "package-offline-osx": "gulp package:offline-osx",
     "package-offline-osx-arm64": "gulp package:offline-osx-arm64",
-    "package-offline-windows": "gulp package:offline-windows"
+    "package-offline-windows": "gulp package:offline-windows",
+    "package-offline-linux": "gulp package:offline-linux"
   },
   "contributes": {
     "grammars": [

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/pgtoolsservice/releases/download/{#version#}/pgsqltoolsservice-{#fileName#}",
-	"version": "v1.8.0",
+	"version": "v1.7.1",
 	"downloadFileNames": {
 		"Windows_64": "win-x64.zip",
 		"Windows_86": "win-x86.zip",

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/pgtoolsservice/releases/download/{#version#}/pgsqltoolsservice-{#fileName#}",
-	"version": "v1.7.1",
+	"version": "v1.8.0",
 	"downloadFileNames": {
 		"Windows_64": "win-x64.zip",
 		"Windows_86": "win-x86.zip",


### PR DESCRIPTION
1. Support Linux executable in the pipeline
2. Disable code signing for offline packages except for Windows. Codesigning removes python executable in OSX offline pakcages.  We need to follow up with ESRP team and the impact of not having code sign in the offline packages. The vsix file is runnable without code sign on OSX.