### PR TITLE
New Pipeline, triggers creating snap branchessnap pipeline

### DIFF
--- a/.pipeline/snap-pipeline.yaml
+++ b/.pipeline/snap-pipeline.yaml
@@ -1,0 +1,22 @@
+trigger: none
+pr:
+  - release
+jobs:
+  - job: build_artifacts
+    displayName: Build and Publish Artifacts
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    - template: templates/build.yml
+    - template: templates/code-sign.yml
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: '$(Build.SourcesDirectory)'
+        contents: '*.vsix'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+      displayName: 'Copy Files'
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: '$(Build.ArtifactStagingDirectory)'
+        artifactName: build
+      displayName: 'Publish Artifacts'


### PR DESCRIPTION
snap-pipeline.yml will be triggered when snap pr into release starts
start PR or build if changes to pgtoolsservice has gone in
does not publish executables to github
Moving forward these executables will be used for bugbash testing